### PR TITLE
Add snippetChooser URL as removed from Wagtail

### DIFF
--- a/wagtail_draftail_snippet/wagtail_hooks.py
+++ b/wagtail_draftail_snippet/wagtail_hooks.py
@@ -68,10 +68,12 @@ def editor_js():
     return format_html(
         """
             <script>
-                window.chooserUrls.snippetLinkModelChooser = '{0}';
-                window.chooserUrls.snippetEmbedModelChooser = '{1}';
+                window.chooserUrls.snippetChooser = '{0}';
+                window.chooserUrls.snippetLinkModelChooser = '{1}';
+                window.chooserUrls.snippetEmbedModelChooser = '{2}';
             </script>
         """,
+        reverse('wagtailsnippets:choose_generic'),
         reverse("wagtaildraftailsnippet:choose-snippet-link-model"),
         reverse("wagtaildraftailsnippet:choose-snippet-embed-model"),
     )


### PR DESCRIPTION
Closes #13 

The package was using snippetChooser URL from Wagtail core but it was [removed](https://github.com/wagtail/wagtail/pull/6419/files) recently for cleanup/improvements.