### PR TITLE
Fix for Wagtail > 2.14

### DIFF
--- a/wagtail_draftail_snippet/urls.py
+++ b/wagtail_draftail_snippet/urls.py
@@ -1,4 +1,7 @@
+from django.urls import path
 from django.conf.urls import url
+
+from wagtail.snippets.views import chooser
 
 from .views import choose_snippet_link_model, choose_snippet_embed_model
 
@@ -6,6 +9,17 @@ from .views import choose_snippet_link_model, choose_snippet_embed_model
 app_name = "wagtaildraftailsnippet"
 
 urlpatterns = [
-    url(r"^choose-link-model/$", choose_snippet_link_model, name="choose-snippet-link-model"),
-    url(r"^choose-embed-model/$", choose_snippet_embed_model, name="choose-snippet-embed-model"),
+    url(
+        r"^choose-link-model/$",
+        choose_snippet_link_model,
+        name="choose-snippet-link-model",
+    ),
+    url(
+        r"^choose-embed-model/$",
+        choose_snippet_embed_model,
+        name="choose-snippet-embed-model",
+    ),
+    path(
+        "choose/", chooser.ChooseView.as_view(), name="choose_generic"
+    ),  # This exists only to get the additional URL params added via JS in wagtail-draftail-snippet.js line 50
 ]

--- a/wagtail_draftail_snippet/wagtail_hooks.py
+++ b/wagtail_draftail_snippet/wagtail_hooks.py
@@ -8,8 +8,10 @@ from wagtail.core import hooks
 
 from . import urls
 from .richtext import (
-    ContentstateSnippetLinkConversionRule, ContentstateSnippetEmbedConversionRule,
-    SnippetLinkHandler, SnippetEmbedHandler,
+    ContentstateSnippetLinkConversionRule,
+    ContentstateSnippetEmbedConversionRule,
+    SnippetLinkHandler,
+    SnippetEmbedHandler,
 )
 
 
@@ -65,18 +67,16 @@ def register_snippet_embed_feature(features):
 
 @hooks.register("insert_editor_js")
 def editor_js():
-    return format_html(
-        """
+
+    html = f"""
             <script>
-                window.chooserUrls.snippetChooser = '{0}';
-                window.chooserUrls.snippetLinkModelChooser = '{1}';
-                window.chooserUrls.snippetEmbedModelChooser = '{2}';
-            </script>
-        """,
-        reverse('wagtailsnippets:choose_generic'),
-        reverse("wagtaildraftailsnippet:choose-snippet-link-model"),
-        reverse("wagtaildraftailsnippet:choose-snippet-embed-model"),
-    )
+                window.chooserUrls.snippetChooser = '{reverse('wagtaildraftailsnippet:choose_generic')}';
+                window.chooserUrls.snippetLinkModelChooser = '{reverse("wagtaildraftailsnippet:choose-snippet-link-model")}';
+                window.chooserUrls.snippetEmbedModelChooser = '{reverse("wagtaildraftailsnippet:choose-snippet-embed-model")}';
+            </script>    
+            """
+
+    return format_html(html)
 
 
 @hooks.register("register_admin_urls")


### PR DESCRIPTION
Newer wagtail broke the choose_generic url that this was using to generically select a snippet. I've added the path back in via this app to hopefully fix the issues. 