### PR TITLE
update to test on 3.7+ and allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
 python:
-- 3.6
 - 3.7
 - 3.8
+- 3.9
 cache: pip
+jobs:
+  fast_finish: true
+  allow_failures:
+    - python: 3.8
+    - python: 3.9
 install:
 - pip install -U pip setuptools
 - pip install .


### PR DESCRIPTION
Updating .travis to use 3.7+ and allow_failure on 3.8, 3.9