### PR TITLE
[DUBS-521] Wagtail 3 and Django 4 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ readme = "README.md"
 license = "BSD-3-Clause"
 
 [tool.poetry.dependencies]
-python = "^3.6"
-wagtail = "^2.5"
+python = ">=3.6"
+wagtail = ">=2.15 <4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 
 [tool.poetry.dependencies]
 python = ">=3.6"
-wagtail = ">=2.15 <4.0"
+wagtail = ">=2.5.0 <4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
             "templates/wagtail_draftail_snippet/*.html",
         ]
     },
-    install_requires=["wagtail==2.*,>=2.5.0"],
+    install_requires=["wagtail>=2.5.0,<4.0"],
     extras_require={
         "dev": [
             "black==19.*,>=19.10.0",

--- a/wagtail_draftail_snippet/static/wagtail_draftail_snippet/js/wagtail-draftail-snippet.js
+++ b/wagtail_draftail_snippet/static/wagtail_draftail_snippet/js/wagtail-draftail-snippet.js
@@ -9,6 +9,7 @@
 
   const TooltipEntity = window.draftail.TooltipEntity;
 
+  const global = globalThis;
   const $ = global.jQuery;
 
   const MUTABILITY = {};

--- a/wagtail_draftail_snippet/urls.py
+++ b/wagtail_draftail_snippet/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-from django.conf.urls import url
 
 from wagtail.snippets.views import chooser
 
@@ -9,13 +8,13 @@ from .views import choose_snippet_link_model, choose_snippet_embed_model
 app_name = "wagtaildraftailsnippet"
 
 urlpatterns = [
-    url(
-        r"^choose-link-model/$",
+    path(
+        "choose-link-model/",
         choose_snippet_link_model,
         name="choose-snippet-link-model",
     ),
-    url(
-        r"^choose-embed-model/$",
+    path(
+        "choose-embed-model/",
         choose_snippet_embed_model,
         name="choose-snippet-embed-model",
     ),

--- a/wagtail_draftail_snippet/wagtail_hooks.py
+++ b/wagtail_draftail_snippet/wagtail_hooks.py
@@ -1,7 +1,7 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext
+from django.utils.translation import gettext
 
 from wagtail.admin.rich_text.editors.draftail import features as draftail_features
 from wagtail.core import hooks
@@ -26,7 +26,7 @@ def register_snippet_link_feature(features):
         "draftail",
         feature_name,
         draftail_features.EntityFeature(
-            {"type": type_, "icon": "snippet", "description": ugettext("Snippet Link")},
+            {"type": type_, "icon": "snippet", "description": gettext("Snippet Link")},
             js=[
                 "wagtailsnippets/js/snippet-chooser-modal.js",
                 "wagtail_draftail_snippet/js/snippet-model-chooser-modal.js",
@@ -51,7 +51,7 @@ def register_snippet_embed_feature(features):
         "draftail",
         feature_name,
         draftail_features.EntityFeature(
-            {"type": type_, "icon": "code", "description": ugettext("Snippet Embed")},
+            {"type": type_, "icon": "code", "description": gettext("Snippet Embed")},
             js=[
                 "wagtailsnippets/js/snippet-chooser-modal.js",
                 "wagtail_draftail_snippet/js/snippet-model-chooser-modal.js",
@@ -81,4 +81,4 @@ def editor_js():
 
 @hooks.register("register_admin_urls")
 def register_admin_urls():
-    return [url(r"^snippets/", include(urls, namespace="wagtaildraftailsnippet"))]
+    return [path("snippets/", include(urls, namespace="wagtaildraftailsnippet"))]


### PR DESCRIPTION
This PR makes the necessary code changes to make `wagtail-draftail-snippet` Wagtail 3 and Django 4 compatible.

It also widens the Wagtail requirement to include Wagtail 3.

The `poetry.lock` file will need to be updated.