### PR TITLE
converting from legacy % to f-strings

### DIFF
--- a/wagtail_draftail_snippet/utils.py
+++ b/wagtail_draftail_snippet/utils.py
@@ -1,8 +1,8 @@
 
 
 def get_snippet_link_frontend_template(app_name, model_name):
-    return "%s/%s_snippet_link.html" % (app_name, model_name)
+    return f"{app_name}/{model_name}_snippet_link.html"
 
 
 def get_snippet_embed_frontend_template(app_name, model_name):
-    return "%s/%s_snippet_embed.html" % (app_name, model_name)
+    return f"{app_name}/{model_name}_snippet_embed.html"


### PR DESCRIPTION
f-strings were introduced in Python 3.6, are faster and could be used to do more dynamic work (not relevant to this use case)